### PR TITLE
Properly set PATH and LD_LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,5 +19,5 @@ curl -L --silent $DOWNLOAD_URL | tar xz
 echo "exporting PATH and LIBRARY_PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/sox.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:vendor/sox/bin"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:$HOME/vendor/sox/bin"' >> $PROFILE_PATH
 echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/sox/lib"' >> $PROFILE_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -20,4 +20,4 @@ echo "exporting PATH and LIBRARY_PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/sox.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="$PATH:$HOME/vendor/sox/bin"' >> $PROFILE_PATH
-echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/sox/lib"' >> $PROFILE_PATH
+echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/vendor/sox/lib"' >> $PROFILE_PATH


### PR DESCRIPTION
The old way didn't work with sox being executed outside (or a few levels deeper) /app dir.